### PR TITLE
Add SPF purchase link to RecommendationCard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,8 +18,8 @@ origins = [
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,          # or ["*"] to allow everything
-    allow_origin_regex=r"^(https?://localhost(:\d+)?|https://.*\.onrender\.com)$",
+    allow_origins=origins,          
+    #allow_origin_regex=r"^(https?://localhost(:\d+)?|https://.*\.onrender\.com)$",
     allow_credentials=True,
     allow_methods=["*"],            # GET, POST, PUT, DELETE, etc.
     allow_headers=["*"],            # Authorization, Content-Type, etc.

--- a/frontend/src/app/(components)/LocationBanner.tsx
+++ b/frontend/src/app/(components)/LocationBanner.tsx
@@ -12,7 +12,7 @@ export default function LocationBanner() {
   const [draft, setDraft] = useState('');
 
   const save = () => {
-    /* naive geocoding via Nominatim; replace with Places API */
+    /* naive geocoding via Nominatim; could also use Places API if I get time*/
     fetch(
       `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
         draft

--- a/frontend/src/app/(components)/RecommendationCard.tsx
+++ b/frontend/src/app/(components)/RecommendationCard.tsx
@@ -7,21 +7,44 @@ import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Button from '@mui/material/Button';
 import { useData } from '../(providers)/data-provider';
 
 export default function RecommendationCard() {
   const { recommendation, loading } = useData();
 
+  // Extract SPF number from the recommendation text
+  const spfMatch = recommendation?.match(/SPF\s*(\d+)/i);
+  const spfValue = spfMatch ? spfMatch[1] : null;
+  // Build purchase link dynamically
+  const purchaseUrl = spfValue
+    ? `https://www.beautyclick.co.ke/?ywcas=1&post_type=product&lang=en_US&s=sunscreen%20spf%20${spfValue}`
+    : null;
+
   return (
     <Card className="p-6 space-y-3">
       <div className="flex items-center gap-2">
         <LightbulbIcon color="warning" />
-        <Typography variant="subtitle2">Your Recommendation</Typography>
+        <Typography variant="subtitle2">Custom Recommendation</Typography>
       </div>
 
       <Typography variant="body1">
         {loading ? 'Loading…' : recommendation ?? '—'}
       </Typography>
+
+      {purchaseUrl && !loading && (
+        <Button
+          size="small"
+          variant="outlined"
+          component="a"
+          href={purchaseUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{ mt: 1, textTransform: 'none' }}
+        >
+          🛒🛍️Purchase SPF {spfValue} Sunscreen
+        </Button>
+      )}
 
       <Accordion sx={{ mt: 2 }}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -30,7 +53,6 @@ export default function RecommendationCard() {
         <AccordionDetails>
           <Typography variant="body2">
             Stay hydrated, use antioxidant serum nightly, and avoid peak sun between 12-3 pm.
-            {/* Static for MVP; replace with API-driven list */}
           </Typography>
         </AccordionDetails>
       </Accordion>


### PR DESCRIPTION
Dynamically extracts the SPF value from the recommendation and displays a purchase button linking to a relevant sunscreen product. Also updates the recommendation label and removes a static comment. Minor comment update in LocationBanner and disables allow_origin_regex in backend CORS config for better security.